### PR TITLE
Importing polycam ply format

### DIFF
--- a/examples/file-loader/src/main.ts
+++ b/examples/file-loader/src/main.ts
@@ -16,9 +16,16 @@ async function selectFile(file: File) {
             console.log("Loading SPLAT file: " + progress);
         });
     } else if (file.name.endsWith(".ply")) {
-        await SPLAT.PLYLoader.LoadFromFileAsync(file, scene, (progress: number) => {
-            console.log("Loading PLY file: " + progress);
-        });
+        const format = "";
+        // const format = "polycam"; // Uncomment to load a Polycam PLY file
+        await SPLAT.PLYLoader.LoadFromFileAsync(
+            file,
+            scene,
+            (progress: number) => {
+                console.log("Loading PLY file: " + progress);
+            },
+            format,
+        );
     }
     loading = false;
 }

--- a/examples/ply-converter/src/main.ts
+++ b/examples/ply-converter/src/main.ts
@@ -9,11 +9,14 @@ const scene = new SPLAT.Scene();
 const camera = new SPLAT.Camera();
 const controls = new SPLAT.OrbitControls(camera, canvas);
 
+const format = "";
+// const format = "polycam"; // Uncomment to use polycam format
+
 async function main() {
     // Load and convert ply from url
     const url =
         "https://huggingface.co/datasets/dylanebert/3dgs/resolve/main/bonsai/point_cloud/iteration_7000/point_cloud.ply";
-    await SPLAT.PLYLoader.LoadAsync(url, scene, (progress) => (progressIndicator.value = progress * 100));
+    await SPLAT.PLYLoader.LoadAsync(url, scene, (progress) => (progressIndicator.value = progress * 100), format);
     progressDialog.close();
     scene.saveToFile("bonsai.splat");
 
@@ -37,9 +40,14 @@ async function main() {
                 progressIndicator.value = progress * 100;
             });
         } else if (file.name.endsWith(".ply")) {
-            await SPLAT.PLYLoader.LoadFromFileAsync(file, scene, (progress: number) => {
-                progressIndicator.value = progress * 100;
-            });
+            await SPLAT.PLYLoader.LoadFromFileAsync(
+                file,
+                scene,
+                (progress: number) => {
+                    progressIndicator.value = progress * 100;
+                },
+                format,
+            );
         }
         scene.saveToFile(file.name.replace(".ply", ".splat"));
         loading = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsplat",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "JavaScript Gaussian Splatting library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
An optional `format: string = "polycam"` argument can now be passed to `PLYLoader.Load` methods to correctly import polycam ply files.