### PR TITLE
feat: add force caching option to reduce costly downloads of scene data

### DIFF
--- a/src/loaders/Loader.ts
+++ b/src/loaders/Loader.ts
@@ -1,10 +1,16 @@
 import type { Scene } from "../core/Scene";
 
 class Loader {
-    static async LoadAsync(url: string, scene: Scene, onProgress?: (progress: number) => void): Promise<void> {
+    static async LoadAsync(
+        url: string,
+        scene: Scene,
+        onProgress?: (progress: number) => void,
+        useCache: boolean = false,
+    ): Promise<void> {
         const req = await fetch(url, {
             mode: "cors",
             credentials: "omit",
+            cache: useCache ? "force-cache" : "default",
         });
 
         if (req.status != 200) {

--- a/src/loaders/PLYLoader.ts
+++ b/src/loaders/PLYLoader.ts
@@ -10,10 +10,12 @@ class PLYLoader {
         scene: Scene,
         onProgress?: (progress: number) => void,
         format: string = "",
+        useCache: boolean = false,
     ): Promise<void> {
         const req = await fetch(url, {
             mode: "cors",
             credentials: "omit",
+            cache: useCache ? "force-cache" : "default",
         });
 
         if (req.status != 200) {


### PR DESCRIPTION
This PR introduces an optional parameter to the LoadAsync functions to use the [`force-cache` option of fetch](https://fetch.spec.whatwg.org/#concept-request-cache-mode).

`force-cache` uses a local cache if available, regardless if the version is stale. This can introduce issues if the file on the server changes, but makes the development with stable scenes much quicker. 

The parameter is optional and turned off per default. Existing applications should work like before.